### PR TITLE
Update Python version dependencies from 3.8+ to 3.8-3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     project_urls={"Bug Tracker": "https://github.com/skhatiri/Aerialist/issues"},
     license="MIT",
     packages=setuptools.find_packages(),
-    python_requires=">=3.7",
+    python_requires=">=3.7, <=3.9",
     include_package_data=True,
     install_requires=[
         "numpy==1.23.2",


### PR DESCRIPTION
Using python versions higher than 3.9 will cause the install of statmodels dependency to fail. Setting python version max to 3.9 will prompt users to downgrade their installation to prevent this. 


Update minimum Python version to 3.8 to match README.md